### PR TITLE
Support Redis url

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,14 @@ JWTSessions.redis_db_name = '0'
 JWTSessions.token_prefix  = 'jwt_' # used for redis db keys
 ```
 
+You can also provide a Redis URL instead:
+
+```ruby
+JWTSessions.redis_url = 'redis://localhost:6397'
+```
+
+**NOTE:** if `REDIS_URL` environment variable is set it is used automatically.
+
 ##### JWT signature
 
 ```ruby

--- a/lib/jwt_sessions.rb
+++ b/lib/jwt_sessions.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'securerandom'
+require 'uri'
 
 require 'jwt_sessions/errors'
 require 'jwt_sessions/token'
@@ -64,6 +65,15 @@ module JWTSessions
     end
   end
 
+  attr_writer :redis_url
+
+  def redis_url
+    return @redis_url if instance_variable_defined?(:@redis_url)
+
+    redis_base_url = ENV['REDIS_URL'] || "redis://#{redis_host}:#{redis_port}"
+    @redis_url = URI.join(redis_base_url, redis_db_name).to_s
+  end
+
   def jwt_options
     @jwt_options ||= JWTOptions.new(*JWT::DefaultOptions::DEFAULT_OPTIONS.values)
   end
@@ -78,7 +88,7 @@ module JWTSessions
   end
 
   def token_store
-    RedisTokenStore.instance(redis_host, redis_port, redis_db_name, token_prefix)
+    RedisTokenStore.instance(redis_url, token_prefix)
   end
 
   def validate?

--- a/lib/jwt_sessions/redis_token_store.rb
+++ b/lib/jwt_sessions/redis_token_store.rb
@@ -5,8 +5,8 @@ require 'redis'
 module JWTSessions
   class RedisTokenStore
     class << self
-      def instance(redis_host, redis_port, redis_db_name, prefix)
-        @_tokens_store ||= Redis.new(url: "redis://#{redis_host}:#{redis_port}/#{redis_db_name}")
+      def instance(redis_url, prefix)
+        @_tokens_store ||= Redis.new(url: redis_url)
         @_token_prefix ||= prefix
 
         new(@_tokens_store, @_token_prefix)

--- a/test/units/test_jwt_sessions.rb
+++ b/test/units/test_jwt_sessions.rb
@@ -4,6 +4,12 @@ require 'minitest/autorun'
 require 'jwt_sessions'
 
 class TestJWTSessions < Minitest::Test
+  def teardown
+    ENV.delete("REDIS_URL")
+    JWTSessions.remove_instance_variable(:@redis_url) if
+     JWTSessions.instance_variable_defined?(:@redis_url)
+  end
+
   def test_default_settings
     assert_equal JWTSessions::DEFAULT_REDIS_HOST, JWTSessions.redis_host
     assert_equal JWTSessions::DEFAULT_REDIS_DB_NAME, JWTSessions.redis_db_name
@@ -34,5 +40,14 @@ class TestJWTSessions < Minitest::Test
     assert_equal JWTSessions.refresh_header, JWTSessions.header_by('refresh')
     assert_equal JWTSessions.access_cookie, JWTSessions.cookie_by('access')
     assert_equal JWTSessions.refresh_cookie, JWTSessions.cookie_by('refresh')
+  end
+
+  def test_redis_url
+    assert_equal "redis://127.0.0.1:6379/0", JWTSessions.redis_url
+  end
+
+  def test_redis_url_with_env_var
+    ENV['REDIS_URL'] = "rediska://locallol:2018/"
+    assert_equal "rediska://locallol:2018/0", JWTSessions.redis_url
   end
 end


### PR DESCRIPTION
- Add `JWTSession.redis_url` as an alternative to setting separate parts
- Use `REDIS_URL` env var if any