### PR TITLE
Remove refresh token from the refresh call results

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ session = JWTSessions::Session.new(payload: payload, refresh_payload: refresh_pa
 ```
 
 Now you can build a refresh endpoint. To protect the endpoint use before_action `authorize_refresh_request!`. \
-In the example `found_token` - is a token fetched from request headers or cookies.
+The endpoint itself should return a renewed access token.
 
 ```ruby
 class RefreshController < ApplicationController
@@ -154,7 +154,7 @@ class RefreshController < ApplicationController
   end
 end
 ```
-
+In the example `found_token` - is a token fetched from request headers or cookies. In the context of `RefreshController` it's a refresh token. \
 The refresh request with headers must include `X-Refresh-Token` (header name is configurable) with refresh token.
 
 ```

--- a/lib/jwt_sessions/session.rb
+++ b/lib/jwt_sessions/session.rb
@@ -187,6 +187,14 @@ module JWTSessions
       }
     end
 
+    def refresh_tokens_hash
+      {
+        csrf: csrf_token,
+        access: access_token,
+        access_expires_at: Time.at(@_access.expiration.to_i)
+      }
+    end
+
     def check_refresh_on_time
       expiration = @_refresh.access_expiration
       yield @_refresh.uid, expiration if expiration.to_i > Time.now.to_i
@@ -197,7 +205,7 @@ module JWTSessions
       create_access_token
       update_refresh_token
 
-      tokens_hash
+      refresh_tokens_hash
     end
 
     def update_refresh_token

--- a/test/support/dummy_api/spec/controllers/refresh_controller_spec.rb
+++ b/test/support/dummy_api/spec/controllers/refresh_controller_spec.rb
@@ -11,7 +11,7 @@ describe RefreshController do
       @tokens = session.login
     end
 
-    EXPECTED_KEYS = %w[access access_expires_at csrf refresh refresh_expires_at].freeze
+    EXPECTED_KEYS = %w[access access_expires_at csrf].freeze
 
     context 'success' do
       let(:refresh_token) { "Bearer #{@tokens[:refresh]}" }

--- a/test/support/dummy_sinatra_api/spec/app_spec.rb
+++ b/test/support/dummy_sinatra_api/spec/app_spec.rb
@@ -3,7 +3,8 @@
 require File.expand_path '../spec_helper.rb', __FILE__
 
 describe 'Sinatra Application' do
-  EXPECTED_KEYS = %w[access access_expires_at csrf refresh refresh_expires_at].freeze
+  LOGIN_KEYS = %w[access access_expires_at csrf refresh refresh_expires_at].freeze
+  REFRESH_KEYS = %w[access access_expires_at csrf].freeze
 
   def json(body)
     JSON.parse(body) rescue {}
@@ -17,7 +18,7 @@ describe 'Sinatra Application' do
   it 'should allow to log in' do
     post '/api/v1/login', format: :json
     expect(last_response).to be_ok
-    expect(json(last_response.body).keys.sort).to eq EXPECTED_KEYS
+    expect(json(last_response.body).keys.sort).to eq LOGIN_KEYS
   end
 
   it 'should allow to refresh' do
@@ -27,7 +28,7 @@ describe 'Sinatra Application' do
     header JWTSessions.refresh_header.downcase.gsub(/\s+/,'_').upcase, refresh_token
     post '/api/v1/refresh', format: :json
     expect(last_response).to be_ok
-    expect(json(last_response.body).keys.sort).to eq EXPECTED_KEYS
+    expect(json(last_response.body).keys.sort).to eq REFRESH_KEYS
   end
 
   it 'should allow to access' do

--- a/test/units/jwt_sessions/test_session.rb
+++ b/test/units/jwt_sessions/test_session.rb
@@ -5,7 +5,8 @@ require 'jwt_sessions'
 
 class TestSession < Minitest::Test
   attr_reader :session, :payload, :tokens
-  EXPECTED_KEYS = %i[access access_expires_at csrf refresh refresh_expires_at].freeze
+  LOGIN_KEYS = %i[access access_expires_at csrf refresh refresh_expires_at].freeze
+  REFRESH_KEYS = %i[access access_expires_at csrf].freeze
 
   def setup
     JWTSessions.encryption_key = 'encrypted'
@@ -22,14 +23,14 @@ class TestSession < Minitest::Test
 
   def test_login
     decoded_access = JWTSessions::Token.decode(tokens[:access]).first
-    assert_equal EXPECTED_KEYS, tokens.keys.sort
+    assert_equal LOGIN_KEYS, tokens.keys.sort
     assert_equal payload[:test], decoded_access['test']
   end
 
   def test_refresh
     refreshed_tokens = session.refresh(tokens[:refresh])
     decoded_access = JWTSessions::Token.decode(refreshed_tokens[:access]).first
-    assert_equal EXPECTED_KEYS, refreshed_tokens.keys.sort
+    assert_equal REFRESH_KEYS, refreshed_tokens.keys.sort
     assert_equal payload[:test], decoded_access['test']
   end
 
@@ -41,7 +42,7 @@ class TestSession < Minitest::Test
     refreshed_tokens = session.refresh_by_access_payload
     access2 = session.instance_variable_get('@_access')
     decoded_access = JWTSessions::Token.decode(refreshed_tokens[:access]).first
-    assert_equal EXPECTED_KEYS, refreshed_tokens.keys.sort
+    assert_equal REFRESH_KEYS, refreshed_tokens.keys.sort
     assert_equal payload[:test], decoded_access['test']
     assert_equal session.instance_variable_get('@_refresh').uid, decoded_access['ruid']
     assert_equal access2.expiration > access1.expiration, true
@@ -54,7 +55,7 @@ class TestSession < Minitest::Test
     refreshed_tokens = session.refresh_by_access_payload
     decoded_access = JWTSessions::Token.decode!(refreshed_tokens[:access]).first
     JWTSessions.access_exp_time = 3600
-    assert_equal EXPECTED_KEYS, refreshed_tokens.keys.sort
+    assert_equal REFRESH_KEYS, refreshed_tokens.keys.sort
     assert_equal payload[:test], decoded_access['test']
     assert_equal session.instance_variable_get('@_refresh').uid, decoded_access['ruid']
   end
@@ -68,7 +69,7 @@ class TestSession < Minitest::Test
     end
     decoded_access = JWTSessions::Token.decode!(refreshed_tokens[:access]).first
     JWTSessions.access_exp_time = 3600
-    assert_equal EXPECTED_KEYS, refreshed_tokens.keys.sort
+    assert_equal REFRESH_KEYS, refreshed_tokens.keys.sort
     assert_equal payload[:test], decoded_access['test']
     assert_equal session.instance_variable_get('@_refresh').uid, decoded_access['ruid']
   end
@@ -100,7 +101,7 @@ class TestSession < Minitest::Test
       raise JWTSessions::Errors::Unauthorized
     end
     decoded_access = JWTSessions::Token.decode(refreshed_tokens[:access]).first
-    assert_equal EXPECTED_KEYS, refreshed_tokens.keys.sort
+    assert_equal REFRESH_KEYS, refreshed_tokens.keys.sort
     assert_equal payload[:test], decoded_access['test']
   end
 


### PR DESCRIPTION
Refresh token is supposed to stay the same during session, doesn't make sense to return it within `refresh` action.