### PR TITLE
validate HTTP Authentication scheme when using header 

### DIFF
--- a/lib/jwt_sessions/authorization.rb
+++ b/lib/jwt_sessions/authorization.rb
@@ -83,7 +83,10 @@ module JWTSessions
 
     def token_from_headers(token_type)
       raw_token = request_headers[JWTSessions.header_by(token_type)] || ''
-      token = raw_token.split(' ')[-1]
+      scheme, token = raw_token.split(' ')
+      unless scheme == 'Bearer'
+        raise Errors::Unauthorized, 'Unsupported HTTP authentication scheme'
+      end
       raise Errors::Unauthorized, 'Token is not found' unless token
       token
     end


### PR DESCRIPTION
Currently JWT_Sessions will happily accept anything that is provided as last word of `Authorization` header. Once the value is accepted, it is parsed and checked for validity. This is problemwatic in situations where Authorization header is used for purposes other than JWT_Session and jwt_session should fall back to using cookie based sessions.

The specific example in which this problem was showing up for me was when attempting migration of app that currently uses HTTP Basic authentication to jwt_sessions in cookie based mode. Client browsers that cached a HTTP Basic Auth credentials were sending requests that had both valid `jwt_access` cookie _and_ `Authorization` header set to `'Basic blahlblha==='.`

In my opinion, such `Authorization` header value should be ignored and the cookies should be checked instead.