### PR TITLE
Document flushing a single session in a namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,13 @@ session = JWTSessions::Session.new(namespace: "ie-sessions")
 session.flush_namespaced # will flush all sessions which belong to the same namespace
 ```
 
+Selectively flush one single session inside a namespace by its access token:
+
+```ruby
+session = JWTSessions::Session.new(namespace: "ie-sessions", payload: payload)
+session.flush_by_access_payload # will flush a specific session which belongs to an existing namespace
+```
+
 Flush access tokens only:
 
 ```ruby


### PR DESCRIPTION
`session = JWTSessions::Session.new(payload: payload); session.flush_by_access_payload` does not work when a session belongs to a namespace and we want to flush only that single session, it throws **Refresh token not found** (even if `refresh_by_access_allowed: true` was set on creation); we have to include the namespace it belongs to.