### PR TITLE
Allow to pass redis client instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,12 @@ JWTSessions.token_store = :redis, {
 }
 ```
 
+If you already have a configured Redis client, you can pass it among the options to reduce opened connections to a Redis server:
+
+```ruby
+JWTSessions.token_store = :redis, {redis_client: Redis.current}
+```
+
 ##### JWT signature
 
 ```ruby

--- a/lib/jwt_sessions/store_adapters/redis_store_adapter.rb
+++ b/lib/jwt_sessions/store_adapters/redis_store_adapter.rb
@@ -7,16 +7,20 @@ module JWTSessions
 
       REFRESH_KEYS = %i[csrf access_uid access_expiration expiration].freeze
 
-      def initialize(token_prefix: JWTSessions.token_prefix, **options)
+      def initialize(token_prefix: JWTSessions.token_prefix, redis_client: nil, **options)
         @prefix = token_prefix
 
-        begin
-          require "redis"
-          @storage = configure_redis_client(**options)
-        rescue LoadError => e
-          msg = "Could not load the 'redis' gem, please add it to your gemfile or " \
-                "configure a different adapter (e.g. JWTSessions.store_adapter = :memory)"
-          raise e.class, msg, e.backtrace
+        if redis_client
+          @storage = redis_client
+        else
+          begin
+            require "redis"
+            @storage = configure_redis_client(**options)
+          rescue LoadError => e
+            msg = "Could not load the 'redis' gem, please add it to your gemfile or " \
+                  "configure a different adapter (e.g. JWTSessions.store_adapter = :memory)"
+            raise e.class, msg, e.backtrace
+          end
         end
       end
 

--- a/test/units/jwt_sessions/store_adapters/test_redis_store_adapter.rb
+++ b/test/units/jwt_sessions/store_adapters/test_redis_store_adapter.rb
@@ -77,4 +77,10 @@ class TestRedisStoreAdapter < Minitest::Test
     adapter = JWTSessions::StoreAdapters::RedisStoreAdapter.new
     assert_equal "redis://127.0.0.2:6322/0", adapter.storage.connection[:id]
   end
+
+  def test_configuration_via_redis_client
+    client = Object.new
+    adapter = JWTSessions::StoreAdapters::RedisStoreAdapter.new(redis_client: client)
+    assert_equal client, adapter.storage
+  end
 end


### PR DESCRIPTION
The main intention of this PR is to make the ability to use the single shared Redis connection per Ruby worker.