### PR TITLE
Add Ruby 3.1 and remove pry

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
-        ruby: ['2.6', '2.7', '3.0']
+        ruby: ['2.6', '2.7', '3.0', '3.1']
         rails: ['5.2.3', '6.0', '6.1', '7.0']
         exclude:
           - ruby: '2.6'
@@ -17,6 +18,10 @@ jobs:
           - ruby: '3.0'
             rails: '5.2.3'
           - ruby: '3.0'
+            rails: '6.0'
+          - ruby: '3.1'
+            rails: '5.2.3'
+          - ruby: '3.1'
             rails: '6.0'
 
     name: Ruby ${{ matrix.ruby }} Rails ${{ matrix.rails }} run
@@ -35,7 +40,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
       - name: Build and test with Rake
         env:
-          RAILS_VERSION: ${{ matrix.rails }}
+          RAILS_VERSION: "~> ${{ matrix.rails }}"
         run: |
           gem update --system
           sudo apt-get update

--- a/test/support/dummy_api/Gemfile
+++ b/test/support/dummy_api/Gemfile
@@ -31,9 +31,6 @@ gem "redis"
 eval_gemfile "../dummy_sinatra_api/Gemfile"
 
 group :development, :test do
-  gem "pry"
-  gem "pry-byebug", "~> 3.4"
-  gem "pry-rails", "~> 0.3.4"
   gem "rspec-rails", ">= 4.0"
   gem "factory_bot_rails", "~> 4.8"
   gem "capybara"


### PR DESCRIPTION
Adds Ruby 3.1 to the CI matrix.

Fixes Rails issues by making the Rails version ~> - allowing us to pick up 6.1.x and 7.0.x versions that are 3.1 compatible.

Also removed pry, as that's not the Ruby debugger going forward.