### PR TITLE
Compatibility with Redis 6+ using the 'redis-client' gem

### DIFF
--- a/lib/jwt_sessions/store_adapters/redis_store_adapter.rb
+++ b/lib/jwt_sessions/store_adapters/redis_store_adapter.rb
@@ -31,8 +31,7 @@ module JWTSessions
 
       def persist_access(uid, csrf, expiration)
         key = access_key(uid)
-        storage.call("SET", key, csrf)
-        storage.call("EXPIREAT", key, expiration)
+        storage.call("SET", key, csrf, ex: expiration)
       end
 
       def fetch_refresh(uid, namespace, first_match = false)

--- a/lib/jwt_sessions/store_adapters/redis_store_adapter.rb
+++ b/lib/jwt_sessions/store_adapters/redis_store_adapter.rb
@@ -17,7 +17,7 @@ module JWTSessions
             require "redis-client"
             @storage = configure_redis_client(**options)
           rescue LoadError => e
-            msg = "Could not load the 'redis' gem, please add it to your gemfile or " \
+            msg = "Could not load the 'redis-client' gem, please add it to your gemfile or " \
                   "configure a different adapter (e.g. JWTSessions.store_adapter = :memory)"
             raise e.class, msg, e.backtrace
           end

--- a/lib/jwt_sessions/store_adapters/redis_store_adapter.rb
+++ b/lib/jwt_sessions/store_adapters/redis_store_adapter.rb
@@ -14,7 +14,7 @@ module JWTSessions
           @storage = redis_client
         else
           begin
-            require "redis"
+            require "redis-client"
             @storage = configure_redis_client(**options)
           rescue LoadError => e
             msg = "Could not load the 'redis' gem, please add it to your gemfile or " \
@@ -25,21 +25,21 @@ module JWTSessions
       end
 
       def fetch_access(uid)
-        csrf = storage.get(access_key(uid))
+        csrf = storage.call("GET", access_key(uid))
         csrf.nil? ? {} : { csrf: csrf }
       end
 
       def persist_access(uid, csrf, expiration)
         key = access_key(uid)
-        storage.set(key, csrf)
-        storage.expireat(key, expiration)
+        storage.call("SET", key, csrf)
+        storage.call("EXPIREAT", key, expiration)
       end
 
       def fetch_refresh(uid, namespace, first_match = false)
         key    = first_match ? first_refresh_key(uid) : full_refresh_key(uid, namespace)
         return {} if key.nil?
 
-        values = storage.hmget(key, *REFRESH_KEYS).compact
+        values = storage.call("HMGET", key, *REFRESH_KEYS).compact
         return {} if values.length != REFRESH_KEYS.length
 
         REFRESH_KEYS
@@ -57,12 +57,12 @@ module JWTSessions
           csrf: csrf,
           namespace: namespace
         )
-        storage.hset(key, :expiration, expiration)
-        storage.expireat(key, expiration)
+        storage.call("HSET", key, :expiration, expiration)
+        storage.call("EXPIREAT", key, expiration)
       end
 
       def update_refresh(uid:, access_expiration:, access_uid:, csrf:, namespace: nil)
-        storage.hmset(
+        storage.call("HMSET",
           full_refresh_key(uid, namespace),
           :csrf, csrf,
           :access_expiration, access_expiration,
@@ -83,11 +83,11 @@ module JWTSessions
 
       def destroy_refresh(uid, namespace)
         key = full_refresh_key(uid, namespace)
-        storage.del(key)
+        storage.call("DEL", key)
       end
 
       def destroy_access(uid)
-        storage.del(access_key(uid))
+        storage.call("DEL", access_key(uid))
       end
 
       private
@@ -103,7 +103,7 @@ module JWTSessions
           redis_db_name: redis_db_name
         )
 
-        Redis.new(options.merge(url: redis_url))
+        RedisClient.new(options.merge(url: redis_url))
       end
 
       def build_redis_url(redis_host: nil, redis_port: nil, redis_db_name: nil)
@@ -152,7 +152,7 @@ module JWTSessions
         all_keys = []
 
         loop do
-          cursor, keys = storage.scan(cursor, match: key_pattern, count: 1000)
+          cursor, keys = storage.call("SCAN", cursor, match: key_pattern, count: 1000)
           all_keys |= keys
 
           break if cursor == "0"

--- a/test/units/jwt_sessions/store_adapters/test_redis_store_adapter.rb
+++ b/test/units/jwt_sessions/store_adapters/test_redis_store_adapter.rb
@@ -26,25 +26,26 @@ class TestRedisStoreAdapter < Minitest::Test
       ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE },
       timeout: 8
     )
-    options = adapter.storage.instance_variable_get(:@options)
+    config = adapter.storage.config
 
-    assert_equal 8, options[:timeout]
-    assert_equal 0, options[:ssl_params][:verify_mode]
+    assert_equal 8, config.instance_variable_get(:@connect_timeout)
+    assert_equal 0, config.instance_variable_get(:@ssl_params)[:verify_mode]
   end
 
   def test_default_url
     adapter = JWTSessions::StoreAdapters::RedisStoreAdapter.new
-    assert_equal "redis://127.0.0.1:6379/0", adapter.storage.connection[:id]
+
+    assert_equal "redis://127.0.0.1:6379/0", adapter.storage.config.server_url
   end
 
   def test_url_with_env_var
     ENV["REDIS_URL"] = "redis://locallol:2018/"
     adapter = JWTSessions::StoreAdapters::RedisStoreAdapter.new
-    assert_equal "redis://locallol:2018/0", adapter.storage.connection[:id]
+    assert_equal "redis://locallol:2018/0", adapter.storage.config.server_url
 
     ENV.delete("REDIS_URL")
     adapter = JWTSessions::StoreAdapters::RedisStoreAdapter.new
-    assert_equal "redis://127.0.0.1:6379/0", adapter.storage.connection[:id]
+    assert_equal "redis://127.0.0.1:6379/0", adapter.storage.config.server_url
   end
 
   def test_configuration_via_host_port_and_db
@@ -53,7 +54,7 @@ class TestRedisStoreAdapter < Minitest::Test
       redis_port: "6372",
       redis_db_name: "2"
     )
-    assert_equal "redis://127.0.0.2:6372/2", adapter.storage.connection[:id]
+    assert_equal "redis://127.0.0.2:6372/2", adapter.storage.config.server_url
   end
 
   def test_configuration_via_host_port_and_db_in_module
@@ -62,18 +63,18 @@ class TestRedisStoreAdapter < Minitest::Test
     JWTSessions.redis_db_name = "2"
 
     adapter = JWTSessions::StoreAdapters::RedisStoreAdapter.new
-    assert_equal "redis://127.0.0.2:6372/2", adapter.storage.connection[:id]
+    assert_equal "redis://127.0.0.2:6372/2", adapter.storage.config.server_url
   end
 
   def test_configuration_via_redis_url
     adapter = JWTSessions::StoreAdapters::RedisStoreAdapter.new(redis_url: "redis://127.0.0.2:6322")
-    assert_equal "redis://127.0.0.2:6322/0", adapter.storage.connection[:id]
+    assert_equal "redis://127.0.0.2:6322/0", adapter.storage.config.server_url
   end
 
   def test_configuration_via_redis_url_in_module
     JWTSessions.redis_url = "redis://127.0.0.2:6322"
     adapter = JWTSessions::StoreAdapters::RedisStoreAdapter.new
-    assert_equal "redis://127.0.0.2:6322/0", adapter.storage.connection[:id]
+    assert_equal "redis://127.0.0.2:6322/0", adapter.storage.config.server_url
   end
 
   def test_configuration_via_redis_client

--- a/test/units/jwt_sessions/test_session.rb
+++ b/test/units/jwt_sessions/test_session.rb
@@ -16,9 +16,9 @@ class TestSession < Minitest::Test
   end
 
   def teardown
-    redis = Redis.new
-    keys = redis.keys("jwt_*")
-    keys.each { |k| redis.del(k) }
+    redis = RedisClient.new
+    keys = redis.call("KEYS", "jwt_*")
+    keys.each { |k| redis.call("DEL", k) }
   end
 
   def test_login

--- a/test/units/test_token_store.rb
+++ b/test/units/test_token_store.rb
@@ -30,7 +30,7 @@ class TestTokenStore < Minitest::Test
     JWTSessions.redis_port = 6378
     JWTSessions.token_store = :redis
 
-    assert_equal "redis://127.0.0.1:6378/0", JWTSessions.token_store.storage.connection[:id]
+    assert_equal "redis://127.0.0.1:6378/0", JWTSessions.token_store.storage.config.server_url
   end
 
   def test_setting_redis_token_store_without_options


### PR DESCRIPTION
Moved from 'redis' to 'redis-client' gem to enable compatibility with Redis 6+.
Adapted the code of the redis_store_adapter.rb to fit the new redis client and updated the tests accordingly. 

Warning: breaks compatibility with 'redis' !