### PR TITLE
Improve handling of tokens 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,9 @@ gemspec
 
 group :test do
   gem "rbnacl"
+  gem "minitest"
+  gem "redis-client"
+  gem "rack-test"
+  gem "sinatra"
+  gem "sinatra-namespace"
 end

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Helper methods within `Authorization` mixin:
 - **payload**: a decoded token's payload.
 - **claimless_payload**: a decoded token's payload without claims validation (can be used for checking data of an expired token).
 - **token_claims**: the method should be defined by a developer and is expected to return a hash-like object with claims to be validated within a token's payload.
+- **decode_access_token**: decodes header or cookie access token. Useful when validation is not required, but
+optional access to the payload is required
 
 ### Rails integration
 

--- a/test/support/dummy_sinatra_api/app.rb
+++ b/test/support/dummy_sinatra_api/app.rb
@@ -152,4 +152,13 @@ namespace "/api/v1" do
     authorize_access_request_by_headers!
     payload.to_json
   end
+
+  get "/payload_without_authorize" do
+    decode_access_token
+    payload.to_json
+  end
+
+  get "/nil_payload" do
+    payload.to_json
+  end
 end

--- a/test/units/jwt_sessions/test_authorization.rb
+++ b/test/units/jwt_sessions/test_authorization.rb
@@ -6,6 +6,10 @@ require "jwt_sessions"
 class TestAuthorization < Minitest::Test
   include JWTSessions::Authorization
 
+  def setup
+    JWTSessions.signing_key = "abcdefghijklmnopqrstuvwxyzABCDEF"
+  end
+
   def test_payload_when_token_is_nil
     @_raw_token = nil
 

--- a/test/units/jwt_sessions/test_authorization.rb
+++ b/test/units/jwt_sessions/test_authorization.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "jwt_sessions"
+
+class TestAuthorization < Minitest::Test
+  include JWTSessions::Authorization
+
+  def test_payload_when_token_is_nil
+    @_raw_token = nil
+
+    assert_equal payload, {}
+  end
+
+  def test_payload_when_token_is_present
+    @_raw_token =
+      JWTSessions::Token.encode({ "user_id" => 1, "secret" => "mystery" })
+
+    assert_equal payload['user_id'], 1
+    assert_equal payload['secret'], 'mystery'
+  end
+end


### PR DESCRIPTION
## Description 
This fixes #128. As mentioned in the original issue, I felt that there should be a separation of concerns between `payload` / token decoding logic and `authorize` methods. The idea is that you should be able to fetch the payload as is, whether it can be decoded or not. While helper methods are there to enforce token validation, just as their name suggests. 

Hence, here are 3 changes that were made:

1. `payload` only tries to decode the token, if it was found. If it's missing, it returns an empty hash
2. `token_from_headers` and `token_from_cookies` has an optional `required` flag, that dictates whatever token must be present. It keeps the original default, where if the token is not present - an error is raised. That was done to make sure there are minimal changes to the existing code
3. New `decode_access_tokens` method, that sets access token from header or cookies. I am not 100% happy with this approach (more in the later section), but this allows making controller actions to have optional validation, with minimal changes to the existing code → if the token is present, it will decode and set the user. If the token is not present, it will do nothing

---

I've also added some gems into as part of `test` group, that were required to run unit tests locally. Let me know if they should be dropped, but I feel like it would be useful to any other contributor to quickly get started, as it did take me a few minutes to figure out why the test suite wasn't running and then finding missing gems.

I am also not sure if it was intentional, but `JWTSessions::Authorization` didn't have any unit tests, so I've added those needed for the introduced changes. Let me know if this was intentional and if there is another way I should be testing this module

## Possible Improvements
Going back to the original thinking on this, ideally, I'd like to completely decouple token accessors from the enforcements present in the code. Meaning I should be able to fetch tokens from headers or cookies, without raising any errors if it's not present. And leave enforcement to `authorize` methods instead, as those would signal that controller **has** to have a valid token

So taking that to the final form, we then won't need to have `decode_access_tokens` method at all, instead we could always call `payload` and it would return nothing or a token, regardless of a helper method being called. While doing the same with aa `authorize_` `before_action` would raise an error, as expected