### PR TITLE
New Release (3.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.2.0 (June 20, 2023)
+
+Features:
+
+ - payload can be accessed without auth - it's going to be resolved into an empty hash.
+
 ## 3.1.1 (May 6, 2023)
 
 Bugfixes:

--- a/README.md
+++ b/README.md
@@ -131,11 +131,9 @@ Helper methods within `Authorization` mixin:
 - **authorize_access_request!**: validates access token within the request.
 - **authorize_refresh_request!**: validates refresh token within the request.
 - **found_token**: a raw token found within the request.
-- **payload**: a decoded token's payload.
+- **payload**: a decoded token's payload. Returns an empty hash in case the token is absent in the request headers/cookies.
 - **claimless_payload**: a decoded token's payload without claims validation (can be used for checking data of an expired token).
 - **token_claims**: the method should be defined by a developer and is expected to return a hash-like object with claims to be validated within a token's payload.
-- **decode_access_token**: decodes header or cookie access token. Useful when validation is not required, but
-optional access to the payload is required
 
 ### Rails integration
 

--- a/jwt_sessions.gemspec
+++ b/jwt_sessions.gemspec
@@ -6,7 +6,7 @@ require "jwt_sessions/version"
 Gem::Specification.new do |s|
   s.name        = "jwt_sessions"
   s.version     = JWTSessions::VERSION
-  s.date        = "2023-05-06"
+  s.date        = "2023-06-20"
   s.summary     = "JWT Sessions"
   s.description = "XSS/CSRF safe JWT auth designed for SPA"
   s.authors     = ["Julija Alieckaja"]

--- a/lib/jwt_sessions/authorization.rb
+++ b/lib/jwt_sessions/authorization.rb
@@ -121,20 +121,21 @@ module JWTSessions
       @_raw_token
     end
 
-    def found_token=(token)
-      @_raw_token = token
-    end
+    def fetch_access_token
+      if respond_to?(:request_headers)
+        token = token_from_headers(:access, required: false)
+        return token if token
+      end
 
-    def decode_access_token
-      token_from_headers(:access, required: false) || token_from_cookies(:access, required: false)
+      token_from_cookies(:access, required: false) if respond_to?(:request_cookies)
     end
 
     def payload
       return @_payload if defined? @_payload
 
       claims = respond_to?(:token_claims) ? token_claims : {}
-      found_token = decode_access_token if found_token.nil?
-      @_payload = found_token ? Token.decode(found_token, claims).first : {}
+      token = found_token || fetch_access_token
+      @_payload = token ? Token.decode(token, claims).first : {}
     end
 
     # retrieves tokens payload without JWT claims validation

--- a/lib/jwt_sessions/authorization.rb
+++ b/lib/jwt_sessions/authorization.rb
@@ -48,10 +48,6 @@ module JWTSessions
       cookieless_auth(:access)
     end
 
-    def decode_access_token
-      @_raw_token = token_from_headers(:access, required: false) || token_from_cookies(:access, required: false)
-    end
-
     private
 
     def invalid_authorization
@@ -125,10 +121,19 @@ module JWTSessions
       @_raw_token
     end
 
+    def found_token=(token)
+      @_raw_token = token
+    end
+
+    def decode_access_token
+      token_from_headers(:access, required: false) || token_from_cookies(:access, required: false)
+    end
+
     def payload
       return @_payload if defined? @_payload
 
       claims = respond_to?(:token_claims) ? token_claims : {}
+      found_token = decode_access_token if found_token.nil?
       @_payload = found_token ? Token.decode(found_token, claims).first : {}
     end
 

--- a/lib/jwt_sessions/version.rb
+++ b/lib/jwt_sessions/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JWTSessions
-  VERSION = "3.1.1"
+  VERSION = "3.2.0"
 end

--- a/test/support/dummy_sinatra_api/app.rb
+++ b/test/support/dummy_sinatra_api/app.rb
@@ -154,11 +154,6 @@ namespace "/api/v1" do
   end
 
   get "/payload_without_authorize" do
-    decode_access_token
-    payload.to_json
-  end
-
-  get "/nil_payload" do
     payload.to_json
   end
 end

--- a/test/support/dummy_sinatra_api/spec/app_spec.rb
+++ b/test/support/dummy_sinatra_api/spec/app_spec.rb
@@ -209,7 +209,7 @@ describe 'Sinatra Application' do
   end
 
   it 'does not raise error when accessing payload' do
-    get '/api/v1/nil_payload', format: :json
+    get '/api/v1/payload_without_authorize', format: :json
 
     expect(last_response).to be_ok
     expect(json(last_response.body)['key']).to be_nil


### PR DESCRIPTION
Convert decode_access_token to private method and call it implicitly, so the payload will automatically resolve into an empty hash when the token is not available.
Bump version.