### PR TITLE
Switching the positions of should_check_csrf? and @_csrf_check in Authorization module.

### DIFF
--- a/lib/jwt_sessions/authorization.rb
+++ b/lib/jwt_sessions/authorization.rb
@@ -55,11 +55,11 @@ module JWTSessions
     end
 
     def refresh_by_access_invalid?
-      should_check_csrf? && @_csrf_check && !JWTSessions::Session.new.valid_access_request?(retrieve_csrf, claimless_payload)
+      @_csrf_check && should_check_csrf? && !JWTSessions::Session.new.valid_access_request?(retrieve_csrf, claimless_payload)
     end
 
     def check_csrf(token_type)
-      invalid_authorization if should_check_csrf? && @_csrf_check && !valid_csrf_token?(retrieve_csrf, token_type)
+      invalid_authorization if @_csrf_check && should_check_csrf? && !valid_csrf_token?(retrieve_csrf, token_type)
     end
 
     def should_check_csrf?


### PR DESCRIPTION
Switching the positions of #should_check_csrf? and @_csrf_check in the code logic serves two important purposes:

Custom Implementation Compatibility:
The first reason for rearranging these checks is to facilitate compatibility with custom implementations, such as when using this module with ActiveInteraction. In cases where there is no method named request_method available, it becomes necessary to override this method and assign a value that is not present in the CSRF_SAFE_METHODS array. However, if cookie validation is not being used, the @_csrf_check rule will not be set anyway. Thus, there is no need to evaluate #should_check_csrf? in this context, making it more efficient and logical to prioritise the @_csrf_check boolean check.

A tinyyyy efficiency improvement:
The second reason for this change is to enhance the efficiency of the code. @_csrf_check is a boolean variable, and checking whether it's set or not is a quicker operation than performing an array inclusion check using #should_check_csrf?. By placing the check for @_csrf_check before #should_check_csrf?, we can potentially save some processing time where access header authorisation is being done.

By making these adjustments, we not only potentially improve code performance but also make it more adaptable to custom implementations, ensuring that the code remains clear and optimized for different use cases.