### PR TITLE
Pass access/refresh claims to session for claim verification

### DIFF
--- a/lib/jwt_sessions/authorization.rb
+++ b/lib/jwt_sessions/authorization.rb
@@ -79,11 +79,11 @@ module JWTSessions
     end
 
     def valid_csrf_token?(csrf_token, token_type)
-      JWTSessions::Session.new.valid_csrf?(found_token, csrf_token, token_type)
+      JWTSessions::Session.new(claims).valid_csrf?(found_token, csrf_token, token_type)
     end
 
     def session_exists?(token_type)
-      JWTSessions::Session.new.session_exists?(found_token, token_type)
+      JWTSessions::Session.new(claims).session_exists?(found_token, token_type)
     end
 
     def cookieless_auth(token_type)
@@ -149,6 +149,13 @@ module JWTSessions
 
       invalid_authorization unless session_exists?(token_type)
       check_csrf(token_type)
+    end
+
+    def claims
+      {
+        access_claims: token_claims,
+        refresh_claims: token_claims
+      }
     end
   end
 end

--- a/test/units/jwt_sessions/test_authorization.rb
+++ b/test/units/jwt_sessions/test_authorization.rb
@@ -6,8 +6,20 @@ require "jwt_sessions"
 class TestAuthorization < Minitest::Test
   include JWTSessions::Authorization
 
+  def token_claims
+    {
+      iss: "issuer",
+      aud: "audience",
+    }
+  end
+
   def setup
     JWTSessions.signing_key = "abcdefghijklmnopqrstuvwxyzABCDEF"
+  end
+
+  def teardown
+    JWTSessions.jwt_options[:verify_iss] = false
+    JWTSessions.jwt_options[:verify_aud] = false
   end
 
   def test_payload_when_token_is_nil
@@ -22,5 +34,95 @@ class TestAuthorization < Minitest::Test
 
     assert_equal payload['user_id'], 1
     assert_equal payload['secret'], 'mystery'
+  end
+
+  def test_verify_iss
+    JWTSessions.jwt_options[:verify_iss] = true
+
+    session = JWTSessions::Session.new(payload: { user_id: 1, iss: "issuer" })
+    tokens = session.login
+
+    # Extract uid from access token
+    uid = JWT.decode(tokens[:access], JWTSessions.public_key).first["uid"]
+
+    @_raw_token =
+      JWTSessions::Token.encode({ user_id: 1, uid: uid, iss: "issuer" })
+
+    assert session_exists?(:access)
+  end
+
+  def test_verify_iss_when_iss_is_not_correct
+    JWTSessions.jwt_options[:verify_iss] = true
+
+    session = JWTSessions::Session.new(payload: { user_id: 1, iss: "issuer" })
+    tokens = session.login
+
+    # Extract uid from access token
+    uid = JWT.decode(tokens[:access], JWTSessions.public_key).first["uid"]
+
+    @_raw_token =
+      JWTSessions::Token.encode({ user_id: 1, uid: uid, iss: "another_issuer" })
+
+    assert !session_exists?(:access)
+  end
+
+  def test_verify_iss_when_iss_is_not_present
+    JWTSessions.jwt_options[:verify_iss] = true
+
+    session = JWTSessions::Session.new(payload: { user_id: 1, iss: "issuer" })
+    tokens = session.login
+
+    # Extract uid from access token
+    uid = JWT.decode(tokens[:access], JWTSessions.public_key).first["uid"]
+
+    @_raw_token =
+      JWTSessions::Token.encode({ user_id: 1, uid: uid })
+
+    assert !session_exists?(:access)
+  end
+
+  def test_verify_aud
+    JWTSessions.jwt_options[:verify_aud] = true
+
+    session = JWTSessions::Session.new(payload: { user_id: 1, aud: "audience" })
+    tokens = session.login
+
+    # Extract uid from access token
+    uid = JWT.decode(tokens[:access], JWTSessions.public_key).first["uid"]
+
+    @_raw_token =
+      JWTSessions::Token.encode({ user_id: 1, uid: uid, aud: "audience" })
+
+    assert session_exists?(:access)
+  end
+
+  def test_verify_aud_when_aud_is_not_correct
+    JWTSessions.jwt_options[:verify_aud] = true
+
+    session = JWTSessions::Session.new(payload: { user_id: 1, aud: "audience" })
+    tokens = session.login
+
+    # Extract uid from access token
+    uid = JWT.decode(tokens[:access], JWTSessions.public_key).first["uid"]
+
+    @_raw_token =
+      JWTSessions::Token.encode({ user_id: 1, uid: uid, aud: "another_audience" })
+
+    assert !session_exists?(:access)
+  end
+
+  def test_verify_aud_when_aud_is_not_present
+    JWTSessions.jwt_options[:verify_aud] = true
+
+    session = JWTSessions::Session.new(payload: { user_id: 1, aud: "audience" })
+    tokens = session.login
+
+    # Extract uid from access token
+    uid = JWT.decode(tokens[:access], JWTSessions.public_key).first["uid"]
+
+    @_raw_token =
+      JWTSessions::Token.encode({ user_id: 1, uid: uid })
+
+    assert !session_exists?(:access)
   end
 end


### PR DESCRIPTION
As of JWT 2.9, token claims that do not pass verification raise an error. JWT 2.8.2 did not display this behaviour. Since jwt_sessions did not pass the token claims, verification always fails (when it's enabled).

```ruby
# jwt 2.8.2
JWT.decode(token, "secret", true, verify_iss: true)
# => [{"exp"=> ...

# jwt 2.9.0
JWT.decode(token, "secret", true, verify_iss: true)
# => Invalid issuer. Expected [], received issuer (JWT::InvalidIssuerError)

JWT.decode(token, "secret", true, verify_iss: true, iss: "issuer")
# => [{"exp"=> ...
```

The same applies to both `verify_iss` and `verify_aud`.